### PR TITLE
Enable build  for ARM processor architectuere

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ADD https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERS
 
 RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
     && cd libsodium-stable \
+    && sed -i -e 's/WASM_INITIAL_MEMORY=4MB/WASM_INITIAL_MEMORY=8MB/g' dist-build/emscripten.sh \
     && dist-build/emscripten.sh --sumo
 
 # Build openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG EMSCRIPTEN_VERSION=3.1.51
+ARG EMSDK_IMAGE=docker.io/emscripten/emsdk
 
 # Build libsodium
-FROM docker.io/emscripten/emsdk:$EMSCRIPTEN_VERSION AS SODIUM
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS SODIUM
 
 ARG LIBSODIUM_VERSION=1.0.19-stable
 
@@ -13,7 +14,7 @@ RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
     && dist-build/emscripten.sh --sumo
 
 # Build openssl
-FROM docker.io/emscripten/emsdk:$EMSCRIPTEN_VERSION AS OPENSSL
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS OPENSSL
 
 ARG OPENSSL_VERSION=1.1.1w
 
@@ -31,7 +32,7 @@ RUN bash -c 'echo "$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256) openssl-${OPE
     && emmake make install
 
 # Build libcrypt4gh
-FROM docker.io/emscripten/emsdk:$EMSCRIPTEN_VERSION AS LIBCRYPT4GH
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS LIBCRYPT4GH
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
@@ -58,7 +59,7 @@ RUN  export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && emmake make install
 
 # Build libcrypt4gh-keys
-FROM docker.io/emscripten/emsdk:$EMSCRIPTEN_VERSION AS LIBCRYPT4GHKEYS
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS LIBCRYPT4GHKEYS
 
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/include/ /emsdk/upstream/include/
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/lib/
@@ -86,7 +87,7 @@ RUN export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && emmake make install
 
 # Build wasm application
-FROM docker.io/emscripten/emsdk:$EMSCRIPTEN_VERSION AS WASMCRYPT
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS WASMCRYPT
 
 LABEL maintainer="CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Build your application
 ## Extras
 You can provide argument variables to change which library versions get built.
 
-`emscripten`, `libsodium`, and `openssl` versions can be changed with `--build-arg` by changing the value of `EMSCRIPTEN_VERSION`, `LIBSODIUM_VERSION`, and `OPENSSL_VERSION`.
+`emscripten`, `libsodium`, and `openssl` versions can be changed with `--build-arg` by changing the value of `EMSCRIPTEN_VERSION`, `LIBSODIUM_VERSION`, `EMSDK_IMAGE` and `OPENSSL_VERSION`.
+
+>__NOTE:__ To build only ARM images use -arm in version tag and for ARM built images. For example `EMSDK_IMAGE --build-arg="EMSDK_IMAGE=sds-docker-local.artifactory.ci.csc.fi/sd-connect/emscripten/emsdk"  --build-arg="EMSCRIPTEN_VERSION=3.1.21-arm"` instructs to use locally build emsdk:3.1.21-arm container. 
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can provide argument variables to change which library versions get built.
 
 `emscripten`, `libsodium`, and `openssl` versions can be changed with `--build-arg` by changing the value of `EMSCRIPTEN_VERSION`, `LIBSODIUM_VERSION`, `EMSDK_IMAGE` and `OPENSSL_VERSION`.
 
->__NOTE:__ To build only ARM images use -arm in version tag and for ARM built images. For example `EMSDK_IMAGE --build-arg="EMSDK_IMAGE=sds-docker-local.artifactory.ci.csc.fi/sd-connect/emscripten/emsdk"  --build-arg="EMSCRIPTEN_VERSION=3.1.21-arm"` instructs to use locally build emsdk:3.1.21-arm container. 
+>__NOTE:__ To build only ARM images use -arm in version tag and for ARM built images. For example `EMSDK_IMAGE --build-arg="EMSDK_IMAGE=<local-registry>/emscripten/emsdk"  --build-arg="EMSCRIPTEN_VERSION=3.1.21-arm"` instructs to use locally build emsdk:3.1.21-arm container. 
 
 # License
 

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" EMCC_FORCE_STDLIBS=libc emmake make $1
+EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" EMCC_FORCE_STDLIBS=libc emmake make $1


### PR DESCRIPTION
To be able to run the containers at Mac M1 processor we need to provide the container images build for ARM

Changes: 

- Dockerfile

   -  Add variable to pass custom made EMSDK image for building docker-container-crypt4gh Docker image for ARM.

- README
  - Add instruction to use build arguments for custom build Docker image.