### PR TITLE
Add multiplatform build update openssl libsodium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG EMSCRIPTEN_VERSION=3.1.43
+ARG EMSDK_IMAGE=emscripten/emsdk
 
 # Build libsodium
-FROM emscripten/emsdk:$EMSCRIPTEN_VERSION AS SODIUM
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS SODIUM
 
 ARG LIBSODIUM_VERSION=1.0.18-stable
 
@@ -13,7 +14,7 @@ RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
     && dist-build/emscripten.sh --sumo
 
 # Build openssl
-FROM emscripten/emsdk:$EMSCRIPTEN_VERSION AS OPENSSL
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS OPENSSL
 
 ARG OPENSSL_VERSION=1.1.1u
 
@@ -31,7 +32,7 @@ RUN bash -c 'echo "$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256) openssl-${OPE
     && emmake make install
 
 # Build libcrypt4gh
-FROM emscripten/emsdk:$EMSCRIPTEN_VERSION AS LIBCRYPT4GH
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS LIBCRYPT4GH
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean; echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
 
@@ -58,7 +59,7 @@ RUN  export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && emmake make install
 
 # Build libcrypt4gh-keys
-FROM emscripten/emsdk:$EMSCRIPTEN_VERSION AS LIBCRYPT4GHKEYS
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS LIBCRYPT4GHKEYS
 
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/include/ /emsdk/upstream/include/
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/lib/
@@ -86,7 +87,7 @@ RUN export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" \
     && emmake make install
 
 # Build wasm application
-FROM emscripten/emsdk:$EMSCRIPTEN_VERSION AS WASMCRYPT
+FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS WASMCRYPT
 
 LABEL maintainer="CSC Developers"
 LABEL org.label-schema.schema-version="1.0"

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ADD https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERS
 
 RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
     && cd libsodium-stable \
+    && sed -i -e 's/WASM_INITIAL_MEMORY=4MB/WASM_INITIAL_MEMORY=8MB/g' dist-build/emscripten.sh \
     && dist-build/emscripten.sh --sumo
 
 # Build openssl

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,8 +72,8 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
     && apt-get upgrade -yq -o Dpkg::Options::="--force-confold" \
     && apt-get install -yq autoconf build-essential pkg-config
 
-ADD https://api.github.com/repos/umccr/libcrypt4gh-keys/compare/main...HEAD /dev/null
-RUN git clone https://github.com/umccr/libcrypt4gh-keys.git
+ADD https://api.github.com/repos/CSCfi/libcrypt4gh-keys/compare/main...HEAD /dev/null
+RUN git clone https://github.com/CSCfi/libcrypt4gh-keys.git
 
 # We'll skip linking libraries since emcc only produces static libraries
 # Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG EMSDK_IMAGE=emscripten/emsdk
 # Build libsodium
 FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS SODIUM
 
-ARG LIBSODIUM_VERSION=1.0.18-stable
+ARG LIBSODIUM_VERSION=1.0.19-stable
 
 ADD https://download.libsodium.org/libsodium/releases/libsodium-${LIBSODIUM_VERSION}.tar.gz .
 
@@ -16,7 +16,7 @@ RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
 # Build openssl
 FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS OPENSSL
 
-ARG OPENSSL_VERSION=1.1.1u
+ARG OPENSSL_VERSION=3.1.4
 
 ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz .
 ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256 .
@@ -28,7 +28,7 @@ RUN bash -c 'echo "$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256) openssl-${OPE
     && sed -i 's|^CROSS_COMPILE.*$|CROSS_COMPILE=|g' Makefile \
     && sed -i '/^CFLAGS/ s/$/ -D__STDC_NO_ATOMICS__=1/' Makefile \
     && sed -i '/^CXXFLAGS/ s/$/ -D__STDC_NO_ATOMICS__=1/' Makefile \
-    && emmake make -j 2 all \
+    && emmake make -j$(nproc) all \
     && emmake make install
 
 # Build libcrypt4gh
@@ -70,10 +70,10 @@ COPY --from=OPENSSL /emsdk/upstream/lib/ /emsdk/upstream/lib/
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     apt-get update -q \
     && apt-get upgrade -yq -o Dpkg::Options::="--force-confold" \
-    && apt-get install -yq autoconf build-essential
+    && apt-get install -yq autoconf build-essential pkg-config
 
-ADD https://api.github.com/repos/cscfi/libcrypt4gh-keys/compare/main...HEAD /dev/null
-RUN git clone https://github.com/CSCfi/libcrypt4gh-keys.git
+ADD https://api.github.com/repos/umccr/libcrypt4gh-keys/compare/main...HEAD /dev/null
+RUN git clone https://github.com/umccr/libcrypt4gh-keys.git
 
 # We'll skip linking libraries since emcc only produces static libraries
 # Linking sodium at this point causes a linker conflict – thus cutting out $(LIBS)

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@ Build your application
 ## Extras
 You can provide argument variables to change which library versions get built.
 
-`emscripten`, `libsodium`, and `openssl` versions can be changed with `--build-arg` by changing the value of `EMSCRIPTEN_VERSION`, `LIBSODIUM_VERSION`, and `OPENSSL_VERSION`.
+`emscripten`, `libsodium`, and `openssl` versions can be changed with `--build-arg` by changing the value of `EMSCRIPTEN_VERSION`, `LIBSODIUM_VERSION`, `EMSDK_IMAGE` and `OPENSSL_VERSION`.
+
+>__NOTE:__ To build only ARM images use -arm in version tag and for ARM built images. For example `EMSDK_IMAGE --build-arg="EMSDK_IMAGE=sds-docker-local.artifactory.ci.csc.fi/sd-connect/emscripten/emsdk"  --build-arg="EMSCRIPTEN_VERSION=3.1.21-arm"` instructs to use locally build emsdk:3.1.21-arm container. 
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can provide argument variables to change which library versions get built.
 
 `emscripten`, `libsodium`, and `openssl` versions can be changed with `--build-arg` by changing the value of `EMSCRIPTEN_VERSION`, `LIBSODIUM_VERSION`, `EMSDK_IMAGE` and `OPENSSL_VERSION`.
 
->__NOTE:__ To build only ARM images use -arm in version tag and for ARM built images. For example `EMSDK_IMAGE --build-arg="EMSDK_IMAGE=sds-docker-local.artifactory.ci.csc.fi/sd-connect/emscripten/emsdk"  --build-arg="EMSCRIPTEN_VERSION=3.1.21-arm"` instructs to use locally build emsdk:3.1.21-arm container. 
+>__NOTE:__ To build only ARM images use -arm in version tag and for ARM built images. For example `EMSDK_IMAGE --build-arg="EMSDK_IMAGE=<local-registry>/emscripten/emsdk"  --build-arg="EMSCRIPTEN_VERSION=3.1.21-arm"` instructs to use locally build emsdk:3.1.21-arm container. 
 
 # License
 

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib" EMCC_FORCE_STDLIBS=libc emmake make $1
+EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" EMCC_FORCE_STDLIBS=libc emmake make $1

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
-EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" EMCC_FORCE_STDLIBS=libc emmake make $1
+EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" EMCC_FORCE_STDLIBS="libc emmake make" $1


### PR DESCRIPTION
Few tweaks to get it working on my M1 with zsh and most importantly, bump up OpenSSL from 1.x to 3.x as 1.1 series is discouraged from upstream.

Do not merge until https://github.com/silverdaz/libcrypt4gh-keys/pull/1 is accepted.