### PR TITLE
use openssl 3.1 and small adjutmets for multiplatform

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG EMSCRIPTEN_VERSION=3.1.51
+ARG EMSCRIPTEN_VERSION=3.1.54
 ARG EMSDK_IMAGE=docker.io/emscripten/emsdk
 
 # Build libsodium
@@ -16,7 +16,7 @@ RUN tar xvf libsodium-${LIBSODIUM_VERSION}.tar.gz \
 # Build openssl
 FROM ${EMSDK_IMAGE}:${EMSCRIPTEN_VERSION} AS OPENSSL
 
-ARG OPENSSL_VERSION=1.1.1w
+ARG OPENSSL_VERSION=3.1.5
 
 ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz .
 ADD https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz.sha256 .
@@ -28,7 +28,7 @@ RUN bash -c 'echo "$(cat openssl-${OPENSSL_VERSION}.tar.gz.sha256) openssl-${OPE
     && sed -i 's|^CROSS_COMPILE.*$|CROSS_COMPILE=|g' Makefile \
     && sed -i '/^CFLAGS/ s/$/ -D__STDC_NO_ATOMICS__=1/' Makefile \
     && sed -i '/^CXXFLAGS/ s/$/ -D__STDC_NO_ATOMICS__=1/' Makefile \
-    && emmake make -j 2 all \
+    && emmake make -j$(nproc) all \
     && emmake make install
 
 # Build libcrypt4gh
@@ -44,7 +44,7 @@ RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/include/ /emsdk/upstream/include/
 COPY --from=SODIUM /src/libsodium-stable/libsodium-js-sumo/lib/ /emsdk/upstream/lib/
 
-ADD https://api.github.com/repos/cscfi/libcrypt4gh/compare/main...HEAD /dev/null
+ADD https://api.github.com/repos/CSCfi/libcrypt4gh/compare/main...HEAD /dev/null
 RUN git clone https://github.com/CSCfi/libcrypt4gh
 
 # We'll skip linking libraries since emcc only produces static libraries
@@ -70,7 +70,7 @@ COPY --from=OPENSSL /emsdk/upstream/lib/ /emsdk/upstream/lib/
 RUN --mount=type=cache,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
     apt-get update -q \
     && apt-get upgrade -yq -o Dpkg::Options::="--force-confold" \
-    && apt-get install -yq autoconf build-essential
+    && apt-get install -yq autoconf build-essential pkg-config
 
 ADD https://api.github.com/repos/cscfi/libcrypt4gh-keys/compare/main...HEAD /dev/null
 RUN git clone https://github.com/CSCfi/libcrypt4gh-keys.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG EMSCRIPTEN_VERSION=3.1.54
+ARG EMSCRIPTEN_VERSION=3.1.57
 ARG EMSDK_IMAGE=docker.io/emscripten/emsdk
 
 # Build libsodium

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,3 +1,3 @@
-#!/bin/bash
+#!/bin/sh
 
-EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" EMCC_FORCE_STDLIBS=libc emmake make $1
+EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" EMCC_FORCE_STDLIBS="libc emmake make" $1

--- a/build_wasm.sh
+++ b/build_wasm.sh
@@ -1,3 +1,6 @@
 #!/bin/sh
 
-EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" EMCC_FORCE_STDLIBS="libc emmake make" $1
+export EMCC_CFLAGS="-I/emsdk/upstream/include -L/emsdk/upstream/lib -sINITIAL_MEMORY=26214400" 
+export EMCC_FORCE_STDLIBS="libc" 
+
+emmake make $1


### PR DESCRIPTION
re-doing some of the changes from https://github.com/CSCfi/docker-emscripten-crypt4gh/pull/15 done by @brainstorm

- update emscripten to 3.1.57
- update openssl to 3.1.5