### PR TITLE
Fix clean-containers

### DIFF
--- a/.github/workflows/clean-containers.yaml
+++ b/.github/workflows/clean-containers.yaml
@@ -6,6 +6,7 @@
 name: ghcr actions
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "21 21 * * *"
 
@@ -18,7 +19,7 @@ jobs:
     steps:
       - name: downcase REPO name
         run: |
-          echo "REPO=${GITHUB_REPOSITORY,,}" >>${GITHUB_ENV}
+          echo "REPO=$(echo $GITHUB_REPOSITORY | cut -f2 -d/)" >> ${GITHUB_ENV}
       - name: Delete 'PR' containers older than a week
         uses: snok/container-retention-policy@v3.0.0
         with:


### PR DESCRIPTION
Finally found the issue. The image name was in the format `org/repository` but it should be only `repository`. So actually this action never worked before '^^. 

Now it does, yay!

Tested it here: https://github.com/CSCfi/tiny-rp/actions/runs/10317443460/job/28561741445

Also marked it with `workflow_dispatch`, so it can be triggered manually.